### PR TITLE
Influence Post-Initialization Settlement Spawning (And Some)

### DIFF
--- a/Source/HarmonyPatches.cs
+++ b/Source/HarmonyPatches.cs
@@ -28,7 +28,7 @@ namespace FactionControl
         }
     }
 
-    [HarmonyPatch(typeof(Page_SelectScenario), "BeginScenarioConfiguration")]
+    [HarmonyPatch(typeof(Page_SelectScenario), nameof(Page_SelectScenario.BeginScenarioConfiguration))]
     static class Patch_Page_SelectScenario_BeginScenarioConfiguration
     {
         [HarmonyPriority(Priority.First)]
@@ -53,7 +53,7 @@ namespace FactionControl
         }
     }
 
-    [HarmonyPatch(typeof(Page_CreateWorldParams), "DoWindowContents")]
+    [HarmonyPatch(typeof(Page_CreateWorldParams), nameof(Page_CreateWorldParams.DoWindowContents))]
     public static class Patch_Page_CreateWorldParams_DoWindowContents
     {
         static void Postfix(Rect rect)
@@ -76,14 +76,13 @@ namespace FactionControl
         }
     }
 
-    [HarmonyPatch(typeof(WorldGenerator), "GenerateWorld")]
+    [HarmonyPatch(typeof(WorldGenerator), nameof(WorldGenerator.GenerateWorld))]
     public class WorldGenerator_Generate
     {
         internal static bool IsGeneratingWorld = false;
         internal static Dictionary<FactionDef, FactionDensity> FDs = new Dictionary<FactionDef, FactionDensity>();
         internal static Dictionary<string, int> FirstSettlementLocation = new Dictionary<string, int>();
         private static Dictionary<FactionDef, int> MaxAtWorldCreate = new Dictionary<FactionDef, int>();
-        internal static HashSet<int> SettlementLocaitons = new HashSet<int>();
         internal static StringBuilder sb = new StringBuilder();
 
         [HarmonyPriority(Priority.First)]
@@ -92,7 +91,6 @@ namespace FactionControl
             IsGeneratingWorld = true;
 
             sb.Clear();
-            SettlementLocaitons.Clear();
             FDs.Clear();
             FirstSettlementLocation.Clear();
             MaxAtWorldCreate.Clear();
@@ -117,7 +115,6 @@ namespace FactionControl
         [HarmonyPriority(Priority.First)]
         public static void Postfix()
         {
-            SettlementLocaitons.Clear();
             FDs.Clear();
             FirstSettlementLocation.Clear();
             if (sb.Length > 0)
@@ -136,7 +133,7 @@ namespace FactionControl
         }
     }
 
-    [HarmonyPatch(typeof(TileFinder), "RandomSettlementTileFor")]
+    [HarmonyPatch(typeof(TileFinder), nameof(TileFinder.RandomSettlementTileFor))]
     public static class TileFinder_RandomSettlementTileFor
     {
         internal static Faction Faction;
@@ -150,8 +147,8 @@ namespace FactionControl
         [HarmonyPriority(Priority.First)]
         static void Postfix(ref int __result, Faction faction, bool mustBeAutoChoosable, Predicate<int> extraValidator)
         {
-            if (!WorldGenerator_Generate.IsGeneratingWorld)
-                return;
+            if (!WorldGenerator_Generate.IsGeneratingWorld) return;
+
             try
             {
                 if (faction != null && faction.Name != null && WorldGenerator_Generate.FirstSettlementLocation != null &&
@@ -169,16 +166,14 @@ namespace FactionControl
         }
     }
 
-    [HarmonyPatch(typeof(TileFinder), "IsValidTileForNewSettlement")]
+    [HarmonyPatch(typeof(TileFinder), nameof(TileFinder.IsValidTileForNewSettlement))]
     public static class TileFinder_IsValidTileForNewSettlement
     {
         static void Postfix(ref bool __result, ref int tile)
         {
-            if (!WorldGenerator_Generate.IsGeneratingWorld || !__result)
-                return;
+            if (!__result) return;
 
-            if (tile == 0 ||
-                WorldGenerator_Generate.SettlementLocaitons.Contains(tile))
+            if (tile == 0)
             {
                 //Log.Message($"- could not place settlement on tile {tile}");
                 __result = false;
@@ -223,12 +218,10 @@ namespace FactionControl
                     }
                 }
             }
-            if (__result)
-                WorldGenerator_Generate.SettlementLocaitons.Add(tile);
         }
     }
 
-    [HarmonyPatch(typeof(FactionGenerator), "GenerateFactionsIntoWorld")]
+    [HarmonyPatch(typeof(FactionGenerator), nameof(FactionGenerator.GenerateFactionsIntoWorld))]
     public class Patch_FactionGenerator_GenerateFactionsIntoWorld
     {
         [HarmonyPriority(Priority.First)]
@@ -256,7 +249,7 @@ namespace FactionControl
     }
 
 
-    [HarmonyPatch(typeof(WorldFactionsUIUtility), "DoRow")]
+    [HarmonyPatch(typeof(WorldFactionsUIUtility), nameof(WorldFactionsUIUtility.DoRow))]
     public class Patch_WorldFactionsUIUtility_DoRow
     {
         [HarmonyPriority(Priority.High)]


### PR DESCRIPTION
* Added code that should influence settlement spawning after game initialization. This includes both save loading and after a game is started/loaded.
* Removed the use of the hash set storing settlement tile index. It has been noted that the base game implementations for finding things have a time complexity of O(n), while finding things in a hash set has a time complexity of O(1). The mod uses a hash set in a postfix to `TileFinder.IsValidTileForNewSettlement()`... which already calls the base game find methods. So the actual time complexity overall is closer to O(n+1), which is effectively O(n). Additionally, the postfix introduces a side effect where passing the same tile parameter to `TileFinder.IsValidTileForNewSettlement()` will return `false` on all calls after the first. This is what causes RimCities' random settlement placement issue. (Originally I planned to create an issue on RimCities' repository, but after examining the code several times I realized that was a symptom to the above.)
* Refactored `HarmonyPatch` attribute declarations to use `nameof` operator to get method names. This has no real effect at runtime (the compiler converts `nameof` into string literals), but could be useful when issues arise due to methods no longer existing/having been renamed.